### PR TITLE
Please use "IP address" instead of it's very sloppy and incorrect abbreviation (i.e. "IP")

### DIFF
--- a/ui/src/components/controls/control-geolocation-info.vue
+++ b/ui/src/components/controls/control-geolocation-info.vue
@@ -69,7 +69,7 @@
 
         <div class="flexRow row">
           <div class="descriptipn">
-            Your IP
+            IP Address
           </div>
 
           <div class="value">

--- a/ui/src/components/settings/settings-connection.vue
+++ b/ui/src/components/settings/settings-connection.vue
@@ -234,7 +234,7 @@
 
         <spinner :loading="isProcessing" />
         <div class="flexRow paramBlock">
-          <div class="defColor paramName">Local IP:</div>
+          <div class="defColor paramName">Local IP Address:</div>
           <div class="detailedParamValue">
             {{ this.$store.state.account.session.WgLocalIP }}
           </div>


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other: update the wording of two UI elements (no functional/API changes)

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [ ] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

I understand, that a lot of people (even/especially in the field of IT) use "IP" when in fact they are talking about an "IP address".
I also understand, that from the context (i.e. there's an actual IP address right next to the "Your IP" label) nobody will misinterpret "IP" as "intellectual property" or as anything else but an "IP address".
Still, the correct term would be "IP address" (or "address" for short).

Dropping the "Your" would make sense as the other labels also don't use it.

Issue number: N/A

## What is the new behavior?

The UI element displays "(Local) IP Address" instead of "Your IP" and "Local IP".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

* [Internet Protocol](https://en.wikipedia.org/wiki/Internet_Protocol)
* [IP address](https://en.wikipedia.org/wiki/IP_address)