### PR TITLE
[feature] UI: Make checkboxes and radios dark in dark theme

### DIFF
--- a/ui/src/components/scss/constants.scss
+++ b/ui/src/components/scss/constants.scss
@@ -33,6 +33,7 @@ $base-font-family: "MainIVPNFont", "SF Pro Text", "Helvetica", "sans-serif";
     --flag-border-color-rgb: 203,210,211; // #cbd2d3;
 
     @media (prefers-color-scheme: dark){
+         color-scheme: dark;
          --text-color-rgb: 255, 255, 255;
          --text-color:rgba(var(--text-color-rgb));
          --text-color-details: #ffffff7f;   //rgba(#ffffff, 0.5); 


### PR DESCRIPTION
Make checkboxes and radios dark in dark theme.

Tested on:
- arm64 SoC running macOS 12.3.1 (aarch64 -> arm64)

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Checkboxes and radios are light in a dark theme.

Issue number: N/A

## What is the new behavior?

Checkboxes and radios are dark in dark theme.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information

I'm not sure if I changed the proper file but I don't know where else it could be added.
