### PR TITLE
ci: Add Dependabot for GitHub Actions

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [ ] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

#100 was closed because it included the other package managers you didn't want to get PRs for. Noticed that a bunch of the actions are behind now, so this will just create PRs to the GitHub Actions. If you leave them pinned to the major version like `@v3` then the noise should be minimal, but you'll get the updates automatically

Issue number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
