### PR TITLE
(CLI) Add -f short option for `ivpn connect -fastest`

### DIFF
--- a/cli/commands/connection.go
+++ b/cli/commands/connection.go
@@ -165,6 +165,7 @@ func (c *CmdConnect) Init() {
 	c.BoolVar(&c.filter_invert, "filter_invert", false, "Invert filtering")
 
 	// Automatic server selection flags
+	c.BoolVar(&c.fastest, "f", false, "Connect to fastest server")
 	c.BoolVar(&c.fastest, "fastest", false, "Connect to fastest server")
 	c.BoolVar(&c.last, "last", false, "Connect with the last used connection parameters")
 	c.BoolVar(&c.any, "any", false, "Use a random server from the found results to connect")


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

This updates `ivpn connect` flag options.

I exclusively use the CLI to manage my IVPN connection and having the `-f` would be helpful. I can use this patch to compile locally, but I'm opening this PR in case it is useful.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?

To connect to the fastest server, the `-fastest` option is required.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue number: N/A

## What is the new behavior?

Now the `-f` flag exists.

Here's a small demonstration:
![image](https://github.com/ivpn/desktop-app/assets/7507990/2e8f9f01-5946-4466-b3e3-d28cac16221e)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information