### PR TITLE
(CLI) Add -p short option for `ivpn connection -pause`

### DIFF
--- a/cli/commands/connection-ctrl.go
+++ b/cli/commands/connection-ctrl.go
@@ -40,6 +40,7 @@ func (c *CmdConnectionControl) Init() {
 	c.KeepArgsOrderInHelp = true
 
 	c.Initialize("connection", "Managing active connection")
+	c.IntVar(&c.pause, "p", 0, "DURATION", "Temporarily pause the connection for a specified duration\n  (DURATION: [1-1440] minutes)")
 	c.IntVar(&c.pause, "pause", 0, "DURATION", "Temporarily pause the connection for a specified duration\n  (DURATION: [1-1440] minutes)")
 	c.BoolVar(&c.resume, "resume", false, "Resume a paused connection")
 


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

This updates ivpn connection flag options to include `ivpn connection -p` as a short option for `-pause`.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

To pause a connection, the `-pause` option is required.

Issue number: N/A

## What is the new behavior?

The `-p` option exists.

Here's a demonstration:
![image](https://github.com/user-attachments/assets/892a396e-23e8-40e2-b3de-7bd7da56c732)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
