### PR TITLE
[fix] MacOS build.sh failing on 15.2 Beta (24C5089c)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@
 # Individual Persons
 
 Alexandr Stelnykovych <alexandr.stelnykovych@ivpn.net>
+Arian Izadi <izadi2000@gmail.com>
 
 
 # Organizations

--- a/daemon/References/macOS/scripts/build-openvpn.sh
+++ b/daemon/References/macOS/scripts/build-openvpn.sh
@@ -40,7 +40,7 @@ echo "************************************************"
 echo "******** Downloading OpenSSL sources..."
 echo "************************************************"
 cd ${BUILD_DIR}
-curl https://www.openssl.org/source/openssl-${OPEN_SSL_VER}.tar.gz | tar zx
+curl -L https://www.openssl.org/source/openssl-${OPEN_SSL_VER}.tar.gz | tar zx
 
 # ##############################################################################
 # Compilation OpenSSl info:

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ These instructions enable you to get the project up and running on your local ma
 
 #### macOS
 
-[Go 1.21+](https://golang.org/); Git; [npm](https://www.npmjs.com/get-npm); [Node.js (18)](https://nodejs.org/); Xcode Command Line Tools.  
+[Go 1.21-1.22.9](https://golang.org/); Git; [npm](https://www.npmjs.com/get-npm); [Node.js (18)](https://nodejs.org/); Xcode Command Line Tools.  
 To compile the OpenVPN/OpenSSL binaries locally, additional packages are required:  
 ```bash
 brew install autoconf automake libtool


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?
Currently, when running the build.sh for macOS it fails to curl OpenSSL, the patch applied for OSX lion breaks the build for OpenVPN, the OpenSSL being used defaults to system and not what was built by the script, Golang 1.23 is not supported, and passing macOS-version-min=10.6 causes build issues.

Issue number: N/A

## What is the new behavior?
Same build workflow, the only changes are flags and updated docs for the correct Golang version. Also, I had enabled lz4 for the OpenVPN build, and it works on M4, I do not have an M1 chip to test.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No 

I had to disable the patching for OSX lion for OpenVPN, so I am pretty sure it will break the build for that specific macOS.

## Other information
