### PR TITLE
Create stale.yml CI action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 1 * * *' # Scheduled to run at 1:30 AM every day
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
+        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        exempt-all-pr-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,11 +3,12 @@
 # You can adjust the behavior by modifying this file.
 # For more information, see:
 # https://github.com/actions/stale
-name: Mark stale issues and pull requests
+name: Mark and close stale issues
 
 on:
   schedule:
-  - cron: '30 1 * * *' # Scheduled to run at 1:30 AM every day
+  - cron: '30 1 * * 2'  # Scheduled to run at 1:30 AM every Tuesday
+  workflow_dispatch:    # Allows manual triggering of the workflow
 
 jobs:
   stale:
@@ -15,14 +16,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
-        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
-        exempt-all-pr-assignees: true
+        
+        debug-only: true # Set to true to enable debug logging
+
+        days-before-pr-stale: 36500 # 100 years. PRs - effectively disabled. 
+
+        days-before-stale: 1095  # 3 years
+        days-before-close: 7    # 1 week
+
+        stale-issue-message: |
+            This issue has been automatically marked as inactive because it has not had activity in the past three years.
+            
+            If no further activity occurs, this issue will be automatically closed in one week in order to increase our focus on active topics.
+
+        close-issue-message: |
+            This issue has been automatically closed because it has not had recent activity. Thank you for your contributions.
+
+            If the issue has not been resolved, you can [find more information in our Help Center](https://www.ivpn.net/knowledgebase/general/).
+        
+        stale-issue-label: 'stale'
+
+        exempt-all-milestones: true
+        exempt-all-assignees: true
+        exempt-issue-labels: 'never-stale'


### PR DESCRIPTION
## Description

Added [Stale](https://github.com/actions/stale) CI action that warns and then closes issues and PRs that have had no activity for a specified amount of time.
Currently default times are in place:

- Mark stale Issues and PRs after 60 days of no activity
- Delete stale Issues and PRs after 7 days
- Assigned PRs are not marked as stale

## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] CI
