### PR TITLE
UI: Auto-reconnect to daemon – simplify connection state machine and reconnect logic

### DIFF
--- a/ui/src/background.js
+++ b/ui/src/background.js
@@ -957,10 +957,12 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
   // MACOS ONLY: install daemon (privileged helper) if required
   if (Platform() === PlatformEnum.macOS && doNotTryToMacosInstall !== true) {
     darwinDaemonInstaller.InstallDaemonIfRequired(
+      // onInstallationStarted:
       () => {
         console.log("Installing daemon...");
         store.commit("daemonIsInstalling", true);
-      }, //onInstallationStarted,
+      }, 
+      // onInstallationFinished:
       (exitCode) => {
         // check if we still need to install helper
         darwinDaemonInstaller.IsDaemonInstallationRequired((code) => {
@@ -977,9 +979,6 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
 
           // daemon installation not required. Connecting to daemon...
 
-          // force UI to show 'connecting' state
-          store.commit("daemonConnectionState", DaemonConnectionType.Connecting);
-
           // show/activate application window
           // (it can happen that app window is overlapped by another windows on a current moment)
           if (store.state.settings.minimizeToTray != true) menuOnShow();
@@ -991,7 +990,7 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
             await connectToDaemon(true, doNotTryToMacosStart);
           }, 500);
         });
-      } //onInstallationFinished
+      }
     );
     return;
   }
@@ -1001,7 +1000,6 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
 
   const scheduleReconnect = () => {
     if (isAppReadyToQuit || _reconnectTimer || store.state.daemonIsOldVersionError === true) return;
-    store.commit("daemonConnectionState", DaemonConnectionType.Connecting);
     _reconnectTimer = setTimeout(() => {
       console.log("Reconnecting to IVPN Daemon...");
       _reconnectTimer = null;
@@ -1011,24 +1009,23 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
 
   // Called by daemon-client on connection state changes.
   // Also handles scheduling a reconnect whenever the connection is lost.
-  const onStateChange = (state) => {
-    store.commit("daemonConnectionState", state);
-    if (state === DaemonConnectionType.NotConnected) {
-      scheduleReconnect();
-    }
+  const onDisconnected = () => {
+    store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
+    scheduleReconnect();
   };
 
-  store.commit("daemonConnectionState", DaemonConnectionType.Connecting);
   try {
-    await daemonClient.ConnectToDaemon(onStateChange, onDaemonExiting);
+    await daemonClient.ConnectToDaemon(onDisconnected, onDaemonExiting);
 
     // initialize app updater
     StartUpdateChecker(OnAppUpdateAvailable);
 
     store.commit("daemonConnectionState", DaemonConnectionType.Connected);
     // Connection is live. When the socket closes unexpectedly,
-    // onStateChange(NotConnected) will fire and scheduleReconnect() will be called.
+    // onDisconnected() will fire and scheduleReconnect() will be called.
   } catch (e) {
+    store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
+
     // MACOS ONLY: try to start daemon (privileged helper)
     if (Platform() === PlatformEnum.macOS && doNotTryToMacosStart !== true) {
       darwinDaemonInstaller.TryStartDaemon();

--- a/ui/src/background.js
+++ b/ui/src/background.js
@@ -952,10 +952,46 @@ function closeUpdateWindow() {
   updateWindow.destroy(); // close();
 }
 
+var _firstDaemonConnectionTime = null; // tracks the time of the first attempt to connect to the daemon
+var _macosStartAttempted = false; // tracks whether TryStartDaemon() was already called once
+
 // INITIALIZE CONNECTION TO A DAEMON
-async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
+async function connectToDaemon() {
+  
+  // helper functions
+  const scheduleReconnect = (timeout) => {
+    if (isAppReadyToQuit || _reconnectTimer || store.state.daemonIsOldVersionError === true) return;
+    if (!timeout) {
+      // During the initial connection phase (first 15 seconds), reconnect quickly to pick up
+      // the daemon as soon as it starts. After that, fall back to a slower retry cadence.
+      const elapsed = _firstDaemonConnectionTime ? new Date() - _firstDaemonConnectionTime : 0;
+      timeout = elapsed < 15 * 1000 ? 500 : 2000;
+    }
+    _reconnectTimer = setTimeout(() => {
+      console.log("Reconnecting to IVPN Daemon...");
+      _reconnectTimer = null;
+      connectToDaemon();
+    }, timeout);
+  };
+  const cancelReconnectTimer = () => {
+    if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+  };
+  const onDaemonDisconnected = () => {
+    store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
+    scheduleReconnect();
+  };
+
+  let isFirstRun = !_firstDaemonConnectionTime;
+
+  _firstDaemonConnectionTime = _firstDaemonConnectionTime || new Date();
+  if (new Date() - _firstDaemonConnectionTime > 16*1000) {
+    // if we were waiting for daemon connection after it was installed for more than 16 seconds 
+    // - reset installation message, user will see NotConnected status 
+    store.commit("daemonIsInstalling", false);  
+  }
+
   // MACOS ONLY: install daemon (privileged helper) if required
-  if (Platform() === PlatformEnum.macOS && doNotTryToMacosInstall !== true) {
+  if (Platform() === PlatformEnum.macOS && isFirstRun) {
     darwinDaemonInstaller.InstallDaemonIfRequired(
       // onInstallationStarted:
       () => {
@@ -984,11 +1020,8 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
           if (store.state.settings.minimizeToTray != true) menuOnShow();
 
           // wait some time to give Daemon chance to fully start
-          setTimeout(async () => {
-            // do not forget to notify that daemon installation is finished
-            store.commit("daemonIsInstalling", false);
-            await connectToDaemon(true, doNotTryToMacosStart);
-          }, 500);
+          cancelReconnectTimer();
+          scheduleReconnect();
         });
       }
     );
@@ -996,52 +1029,34 @@ async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
   }
 
   // Cancel any pending reconnect timer (e.g., if called manually while a timer is pending)
-  if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
-
-  const scheduleReconnect = () => {
-    if (isAppReadyToQuit || _reconnectTimer || store.state.daemonIsOldVersionError === true) return;
-    _reconnectTimer = setTimeout(() => {
-      console.log("Reconnecting to IVPN Daemon...");
-      _reconnectTimer = null;
-      connectToDaemon(true, true);
-    }, 2000);
-  };
-
-  // Called by daemon-client on connection state changes.
-  // Also handles scheduling a reconnect whenever the connection is lost.
-  const onDisconnected = () => {
-    store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
-    scheduleReconnect();
-  };
+  cancelReconnectTimer();
 
   try {
-    await daemonClient.ConnectToDaemon(onDisconnected, onDaemonExiting);
+    await daemonClient.ConnectToDaemon(onDaemonDisconnected, onDaemonExiting);
 
     // initialize app updater
     StartUpdateChecker(OnAppUpdateAvailable);
 
     store.commit("daemonConnectionState", DaemonConnectionType.Connected);
+    store.commit("daemonIsInstalling", false);
     // Connection is live. When the socket closes unexpectedly,
     // onDisconnected() will fire and scheduleReconnect() will be called.
   } catch (e) {
-    store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
-
-    // MACOS ONLY: try to start daemon (privileged helper)
-    if (Platform() === PlatformEnum.macOS && doNotTryToMacosStart !== true) {
+    // MACOS ONLY: try to start daemon (privileged helper) – only once
+    if (Platform() === PlatformEnum.macOS && !_macosStartAttempted) {
+      _macosStartAttempted = true;
       darwinDaemonInstaller.TryStartDaemon();
-      // Cancel any pending reconnect and wait briefly for the daemon to start
-      if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
-      _reconnectTimer = setTimeout(() => {
-        _reconnectTimer = null;
-        connectToDaemon(true, true); // doNotTryToMacosStart=true: don't call TryStartDaemon again
-      }, 500);
+      // Wait briefly for the daemon to start, then retry.
+      cancelReconnectTimer();
+      scheduleReconnect();
       return;
     }
 
+    store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
+
     if (e.unsupportedDaemonVersion === true) {
-      // Unsupported version requires an app update, not a retry.
-      // Cancel any reconnect timer that may have been set by onStateChange before this catch ran.
-      if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+      // Unsupported version requires an app update — do not retry.
+      cancelReconnectTimer();
       return;
     }
 

--- a/ui/src/background.js
+++ b/ui/src/background.js
@@ -70,6 +70,7 @@ let win;
 let settingsWindow;
 let updateWindow;
 let isAppReadyToQuit = false;
+let _reconnectTimer = null; // timer for reconnecting to daemon after connection loss
 
 let isTrayInitialized = false;
 let lastRouteArgs = null; // last route arguments (requested by renderer process when window initialized)
@@ -952,13 +953,9 @@ function closeUpdateWindow() {
 }
 
 // INITIALIZE CONNECTION TO A DAEMON
-async function connectToDaemon(
-  doNotTryToInstall,
-  isCanRetry,
-  doNotTryToMacosStart
-) {
+async function connectToDaemon(doNotTryToMacosInstall, doNotTryToMacosStart) {
   // MACOS ONLY: install daemon (privileged helper) if required
-  if (Platform() === PlatformEnum.macOS && doNotTryToInstall !== true) {
+  if (Platform() === PlatformEnum.macOS && doNotTryToMacosInstall !== true) {
     darwinDaemonInstaller.InstallDaemonIfRequired(
       () => {
         console.log("Installing daemon...");
@@ -969,16 +966,9 @@ async function connectToDaemon(
         darwinDaemonInstaller.IsDaemonInstallationRequired((code) => {
           if (code == 0) {
             // error: the helper not installed (we still detecting that helper must be installed (code == 0))
-            console.error(
-              `Error installing helper [code1: ${exitCode}, code2: ${code}]`
-            );
-
+            console.error(`Error installing helper [code1: ${exitCode}, code2: ${code}]`);
             // set daemon state 'NotConnected'
-            store.commit(
-              "daemonConnectionState",
-              DaemonConnectionType.NotConnected
-            );
-
+            store.commit("daemonConnectionState", DaemonConnectionType.NotConnected);
             // do not forget to notify that daemon installation is finished
             store.commit("daemonIsInstalling", false);
             // Skip connection to daemon
@@ -988,10 +978,7 @@ async function connectToDaemon(
           // daemon installation not required. Connecting to daemon...
 
           // force UI to show 'connecting' state
-          store.commit(
-            "daemonConnectionState",
-            DaemonConnectionType.Connecting
-          );
+          store.commit("daemonConnectionState", DaemonConnectionType.Connecting);
 
           // show/activate application window
           // (it can happen that app window is overlapped by another windows on a current moment)
@@ -1001,12 +988,7 @@ async function connectToDaemon(
           setTimeout(async () => {
             // do not forget to notify that daemon installation is finished
             store.commit("daemonIsInstalling", false);
-
-            // if success - try to connect to daemon with possibility to retry (wait until daemon start)
-            // (doNotTryToInstall=true, isCanRetry=true)
-            if (exitCode == 0)
-              await connectToDaemon(true, true, doNotTryToMacosStart);
-            else await connectToDaemon(true, false, doNotTryToMacosStart);
+            await connectToDaemon(true, doNotTryToMacosStart);
           }, 500);
         });
       } //onInstallationFinished
@@ -1014,60 +996,61 @@ async function connectToDaemon(
     return;
   }
 
-  let setConnState = function (state) {
-    setTimeout(() => store.commit("daemonConnectionState", state), 0);
+  // Cancel any pending reconnect timer (e.g., if called manually while a timer is pending)
+  if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+
+  const scheduleReconnect = () => {
+    if (isAppReadyToQuit || _reconnectTimer || store.state.daemonIsOldVersionError === true) return;
+    store.commit("daemonConnectionState", DaemonConnectionType.Connecting);
+    _reconnectTimer = setTimeout(() => {
+      console.log("Reconnecting to IVPN Daemon...");
+      _reconnectTimer = null;
+      connectToDaemon(true, true);
+    }, 2000);
   };
 
-  let onSetConnState = function (state) {
-    // do not set 'NotConnected' state if we still trying to reconnect
-    if (
-      state === DaemonConnectionType.NotConnected &&
-      store.state.daemonConnectionState !== DaemonConnectionType.Connected
-    )
-      return;
-
+  // Called by daemon-client on connection state changes.
+  // Also handles scheduling a reconnect whenever the connection is lost.
+  const onStateChange = (state) => {
     store.commit("daemonConnectionState", state);
-  };
-
-  setConnState(DaemonConnectionType.Connecting);
-  let connect = async function (retryNo) {
-    try {
-      await daemonClient.ConnectToDaemon(onSetConnState, onDaemonExiting);
-
-      // initialize app updater
-      StartUpdateChecker(OnAppUpdateAvailable);
-
-      setConnState(DaemonConnectionType.Connected);
-    } catch (e) {
-      // MACOS ONLY: try to start daemon (privileged helper)
-      if (Platform() === PlatformEnum.macOS && doNotTryToMacosStart != true) {
-        darwinDaemonInstaller.TryStartDaemon();
-        // wait some time to give Daemon chance to fully start
-        setTimeout(async () => {
-          // if success - try to connect to daemon with possibility to retry (wait until daemon start)
-          // (doNotTryToInstall=true, isCanRetry=true, doNotTryToMacosStart=true)
-          await connectToDaemon(true, true, true);
-        }, 500);
-        return;
-      }
-
-      if (
-        e.unsupportedDaemonVersion === true ||
-        isCanRetry != true ||
-        retryNo > 15
-      ) {
-        setConnState(DaemonConnectionType.NotConnected);
-      } else {
-        // force UI to show 'connecting' state
-        setConnState(DaemonConnectionType.Connecting);
-        console.log(`Connecting to IVPN Daemon (retry #${retryNo}) ...`);
-        setTimeout(async () => {
-          await connect(retryNo + 1);
-        }, 1000);
-      }
+    if (state === DaemonConnectionType.NotConnected) {
+      scheduleReconnect();
     }
   };
-  connect(1);
+
+  store.commit("daemonConnectionState", DaemonConnectionType.Connecting);
+  try {
+    await daemonClient.ConnectToDaemon(onStateChange, onDaemonExiting);
+
+    // initialize app updater
+    StartUpdateChecker(OnAppUpdateAvailable);
+
+    store.commit("daemonConnectionState", DaemonConnectionType.Connected);
+    // Connection is live. When the socket closes unexpectedly,
+    // onStateChange(NotConnected) will fire and scheduleReconnect() will be called.
+  } catch (e) {
+    // MACOS ONLY: try to start daemon (privileged helper)
+    if (Platform() === PlatformEnum.macOS && doNotTryToMacosStart !== true) {
+      darwinDaemonInstaller.TryStartDaemon();
+      // Cancel any pending reconnect and wait briefly for the daemon to start
+      if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+      _reconnectTimer = setTimeout(() => {
+        _reconnectTimer = null;
+        connectToDaemon(true, true); // doNotTryToMacosStart=true: don't call TryStartDaemon again
+      }, 500);
+      return;
+    }
+
+    if (e.unsupportedDaemonVersion === true) {
+      // Unsupported version requires an app update, not a retry.
+      // Cancel any reconnect timer that may have been set by onStateChange before this catch ran.
+      if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+      return;
+    }
+
+    // Connection failed (e.g., daemon not running yet). Schedule a reconnect.
+    scheduleReconnect();
+  }
 }
 
 function showSettings(settingsViewName) {

--- a/ui/src/components/Component-Init.vue
+++ b/ui/src/components/Component-Init.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="flexColumn">
-  
-    <div v-if="isInitialization" class="main small_text"></div>
-    <div class="main" v-else-if="isDaemonInstalling">
+
+    <div class="main" v-if="isDaemonInstalling">
       Installing IVPN Daemon ...
       <div class="small_text" style="margin-top: 10px">
         Please follow the instructions in the dialog
       </div>
     </div>
+
+    <div v-else-if="isInitialization" class="main small_text"></div>
+
     <div v-else class="flexColumn">
       <div class="main">
         <div class="large_text">Error connecting to IVPN daemon</div>
@@ -61,26 +63,18 @@
 </template>
 
 <script>
+
 import { Platform, PlatformEnum } from "@/platform/platform";
-import { DaemonConnectionType } from "@/store/types";
-const sender = window.ipcSender;
 import config from "@/config";
+
+const sender = window.ipcSender;
 
 export default {
   components: { },
   data: function () {
-    return {
-      isDelayElapsedAfterMount: false,
-    };
+    return { };
   },
-  mounted() {
-    // In order to avoid text blinking, we are showing blank view first few seconds
-    // untill 'daemonConnectionState' will not be initialised.
-    // The blank view also will be visible first few seconds even after 'daemonConnectionState' was intialized by 'Connecting'
-    setTimeout(() => {
-      this.isDelayElapsedAfterMount = true;
-    }, 3000);
-  },
+  mounted() { },
   methods: {
     async ConnectToDaemon() {
       try {
@@ -101,14 +95,7 @@ export default {
       return this.$store.state.daemonIsInstalling;
     },
     isInitialization: function () {
-      if (this.isDelayElapsedAfterMount) return false;
-      return this.isConnecting || (this.$store.state.daemonConnectionState == null && !this.isDaemonInstalling);
-    },
-    isConnecting: function () {
-      return (
-        this.$store.state.daemonConnectionState ===
-        DaemonConnectionType.Connecting
-      );
+      return this.$store.state.daemonConnectionState == null;
     },
     minRequiredVer: function () {
       return config.MinRequiredDaemonVer;

--- a/ui/src/components/Component-Init.vue
+++ b/ui/src/components/Component-Init.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="flexColumn">
+    <spinner :loading="spinnerVisible" />
 
     <div class="main" v-if="isDaemonInstalling">
       Installing IVPN Daemon ...
@@ -64,13 +65,14 @@
 
 <script>
 
+import spinner from "@/components/controls/control-spinner.vue";
 import { Platform, PlatformEnum } from "@/platform/platform";
 import config from "@/config";
 
 const sender = window.ipcSender;
 
 export default {
-  components: { },
+  components: { spinner, },
   data: function () {
     return { };
   },
@@ -96,6 +98,9 @@ export default {
     },
     isInitialization: function () {
       return this.$store.state.daemonConnectionState == null;
+    },
+    spinnerVisible: function () {
+      return this.isDaemonInstalling && this.$store.state.daemonConnectionState != null;
     },
     minRequiredVer: function () {
       return config.MinRequiredDaemonVer;

--- a/ui/src/components/Component-Init.vue
+++ b/ui/src/components/Component-Init.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="flexColumn">
-    <spinner :loading="isProcessing" />
-
+  
     <div v-if="isInitialization" class="main small_text"></div>
     <div class="main" v-else-if="isDaemonInstalling">
       Installing IVPN Daemon ...
@@ -9,7 +8,6 @@
         Please follow the instructions in the dialog
       </div>
     </div>
-    <div v-else-if="isConnecting" class="main small_text">Connecting ...</div>
     <div v-else class="flexColumn">
       <div class="main">
         <div class="large_text">Error connecting to IVPN daemon</div>
@@ -63,19 +61,15 @@
 </template>
 
 <script>
-import spinner from "@/components/controls/control-spinner.vue";
 import { Platform, PlatformEnum } from "@/platform/platform";
 import { DaemonConnectionType } from "@/store/types";
 const sender = window.ipcSender;
 import config from "@/config";
 
 export default {
-  components: {
-    spinner,
-  },
+  components: { },
   data: function () {
     return {
-      isProcessing: false,
       isDelayElapsedAfterMount: false,
     };
   },
@@ -107,12 +101,8 @@ export default {
       return this.$store.state.daemonIsInstalling;
     },
     isInitialization: function () {
-      return (
-        (this.$store.state.daemonConnectionState == null &&
-          !this.isDaemonInstalling &&
-          this.isDelayElapsedAfterMount == false) ||
-        (this.isConnecting && this.isDelayElapsedAfterMount == false)
-      );
+      if (this.isDelayElapsedAfterMount) return false;
+      return this.isConnecting || (this.$store.state.daemonConnectionState == null && !this.isDaemonInstalling);
     },
     isConnecting: function () {
       return (
@@ -131,11 +121,6 @@ export default {
     },
     isMacOS: function () {
       return Platform() === PlatformEnum.macOS;
-    },
-  },
-  watch: {
-    isConnecting() {
-      this.isProcessing = this.isConnecting;
     },
   },
 };
@@ -186,8 +171,16 @@ export default {
   line-height: 20px;
   text-align: center;
   letter-spacing: -0.4px;
-  color: #6d849a;
+  color: #556574; // #6d849a;
 
   cursor: pointer;
+  opacity: 0.8;
+}
+.btn:hover {
+  opacity: 1;
+  border-color: #5a7a94;
+}
+.btn:active {
+  opacity: 0.75;
 }
 </style>

--- a/ui/src/daemon-client/index.js
+++ b/ui/src/daemon-client/index.js
@@ -35,7 +35,6 @@ import { InitConnectionParamsObject } from "@/daemon-client/connectionParams.js"
 import {
   VpnTypeEnum,
   VpnStateEnum,
-  DaemonConnectionType,
   DnsEncryption,
   PortTypeEnum,
 } from "@/store/types";
@@ -763,7 +762,7 @@ async function startNotifyDaemonOnParamsChange() {
   NotifyDaemonConnectionSettings();
 }
 
-async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
+async function ConnectToDaemon(onDisconnected, onDaemonExitingCallback) {
   _onDaemonExitingCallback = onDaemonExitingCallback;
 
   if (socket != null) {
@@ -771,10 +770,7 @@ async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
     socket = null;
   }
 
-  if (setConnState === undefined)
-    setConnState = function (state) {
-      store.commit("daemonConnectionState", state);
-    };
+  if (onDisconnected === undefined) onDisconnected = function () {};
 
   // Read information about connection parameters from a file
   let portFile = await GetPortInfoFilePath();
@@ -793,7 +789,6 @@ async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
 
   return new Promise((resolve, reject) => {
     if (!portInfo) {
-      setConnState(DaemonConnectionType.NotConnected);
       reject("IVPN daemon connection info is unknown.");
       return;
     }
@@ -817,7 +812,6 @@ async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
         try {
           const disconnectDaemonFunc = function (err) {
             if (!err) return;
-            setConnState(DaemonConnectionType.NotConnected);
 
             if (socket) {
               socket.destroy();
@@ -832,8 +826,6 @@ async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
             waitForCommandsList: [daemonResponses.ServerListResp],
           };
           let promiseWaiterServers = null;
-
-          setConnState(DaemonConnectionType.Connecting);
 
           if (isNeedConvertSettings !== true)
             promiseWaiterServers = addWaiter(svrListWaiter, 11000);
@@ -865,9 +857,6 @@ async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
             return;
           }
 
-          // Saving 'connected' state to a daemon
-          setConnState(DaemonConnectionType.Connected);
-
           // start daemon notification about connection parameters change
           startNotifyDaemonOnParamsChange();
 
@@ -882,8 +871,8 @@ async function ConnectToDaemon(setConnState, onDaemonExitingCallback) {
       .on("data", onDataReceived);
 
     socket.on("close", () => {
-      // Save 'disconnected' state
-      setConnState(DaemonConnectionType.NotConnected);
+      // Notify 'disconnected' state
+      onDisconnected();
       log.debug("Connection closed");
 
       socket = null;

--- a/ui/src/store/types.js
+++ b/ui/src/store/types.js
@@ -22,7 +22,6 @@
 
 export const DaemonConnectionType = Object.freeze({
   NotConnected: 0,
-  Connecting: 1,
   Connected: 2,
 });
 

--- a/ui/src/views/Component-Main.vue
+++ b/ui/src/views/Component-Main.vue
@@ -84,11 +84,7 @@ export default {
     },
     currentViewComponent: function () {
       const daemonConnection = this.$store.state.daemonConnectionState;
-      if (
-        daemonConnection == null ||
-        daemonConnection === DaemonConnectionType.NotConnected ||
-        daemonConnection === DaemonConnectionType.Connecting
-      )
+      if (daemonConnection !== DaemonConnectionType.Connected)
         return Init;
       if (this.$store.state.uiState.isParanoidModePasswordView === true)
         return ParanoidModePassword;


### PR DESCRIPTION
### Summary

New functionality: UI auto-reconnection on unexpected disconnection from the daemon.

Refactors the daemon connection layer in the UI to make reconnect behaviour more robust and the code easier to reason about.

---

### What changed

#### `background.js`
- `connectToDaemon()` becomes **parameterless** — all three parameters
  (`doNotTryToInstall`, `isCanRetry`, `doNotTryToMacosStart`) are removed.
- Two module-level flags replace the parameters:
  - `_firstDaemonConnectionTime` — tracks when the first connection attempt
    began; used to differentiate the initial run from reconnects.
  - `_macosStartAttempted` — ensures `TryStartDaemon()` is called at most once.
- The recursive inner `connect(retryNo)` function is replaced by a
  `scheduleReconnect()` / `cancelReconnectTimer()` pair backed by a
  module-level `_reconnectTimer`. During the first 15 s, retries fire every
  500 ms; after that, every 2 s.
- All `daemonConnectionState` store commits are now exclusively owned by
  `background.js`. `Connected` and `daemonIsInstalling = false` are set in
  the success path; `NotConnected` is set in error paths and in the
  `onDaemonDisconnected` callback.
- A 16-second elapsed check resets `daemonIsInstalling` if the daemon takes
  too long after installation.

#### `daemon-client/index.js`
- Signature changes from `ConnectToDaemon(setConnState, …)` to
  `ConnectToDaemon(onDisconnected, …)`.
- All `setConnState()` calls (`Connecting`, `Connected`, `NotConnected`)
  removed — the module no longer writes to the store at all.
- `onDisconnected()` is called only on socket close, notifying the caller to
  schedule a reconnect.
- `DaemonConnectionType` import removed (no longer needed).

#### `store/types.js`
- `DaemonConnectionType.Connecting` (value `1`) removed.  
  The enum now has exactly three values: `null` (uninitialized),
  `NotConnected: 0`, `Connected: 2`.

#### `Component-Init.vue`
- Template reordered: `isDaemonInstalling` is checked before
  `isInitialization`.
- "Connecting …" `div` and its `v-else-if="isConnecting"` branch removed.
- `isProcessing`, `isDelayElapsedAfterMount` data fields and the 3-second
  `setTimeout` in `mounted()` removed.
- `isInitialization` simplified to `daemonConnectionState == null`.
- `isConnecting` computed and its watcher removed.
- `spinnerVisible` computed added: spinner shows only when
  `isDaemonInstalling && daemonConnectionState != null`.
- Minor CSS additions: button hover/active states.

#### `Component-Main.vue`
- Multi-condition `if (null || NotConnected || Connecting)` replaced with a
  single `if (daemonConnection !== Connected)`.