### PR TITLE
app-updater: minOsVersion gating, optional notes, macOS permission fixes (#565)

### DIFF
--- a/ui/References/macOS/HelperProjects/uninstaller/etc/install.sh
+++ b/ui/References/macOS/HelperProjects/uninstaller/etc/install.sh
@@ -106,14 +106,32 @@ function CheckSignature
     return 0
 }
 
-function FixInstalledAppPermissions
-{
-    # Make app bundle traversable/readable for normal users while preserving
-    # executable bits for binaries and scripts.
-    chown -R root:wheel "${_app_path}" || return 1
-    chmod -R a+rX,go-w "${_app_path}" || return 1
-    return 0
-}
+# Can be executed after the update is installed, but before the app is started. 
+#
+# What this function used to do:
+# 1) Recursively set owner/group of all files in IVPN.app to root:wheel.
+# 2) Recursively normalize permissions for all paths except
+#    Contents/Resources/etc using: chmod a+rX,go-w
+#    - add read for everyone
+#    - add execute only to directories (and already executable files)
+#    - remove write for group/others
+# 3) Return non-zero on failure so update script could rollback.
+#
+# WARNING:
+# Permission/ownership normalization from updater can conflict with daemon
+# file-rights policy and silently create late regressions after updates.
+# Example: static files in Contents/Resources/etc must keep strict modes
+# expected by daemon checks (e.g. 0400). Broad chmod/chown logic may alter
+# those assumptions over time.
+#
+# function FixInstalledAppPermissions
+# {
+#     chown -R root:wheel "${_app_path}" || return 1
+#     find "${_app_path}" \
+#         -path "${_app_path}/Contents/Resources/etc" -prune \
+#         -o -exec chmod a+rX,go-w {} + || return 1
+#     return 0
+# }
 
 if [ -z "${_source_dmg}" ]; then
   echoerr "Source dmg file not defined."
@@ -192,9 +210,6 @@ fi
 
 echo "[+] Copying ..."
 cp -R "${_app_path_src}" "${_app_path}" || { echoerr "Failed to install the update"; RestoreBackup; UnmountDMG; exit 72; }
-
-echo "[+] Fixing permissions ..."
-FixInstalledAppPermissions || { echoerr "Failed to fix application permissions"; RestoreBackup; UnmountDMG; exit 73; }
 
 RemoveBackup
 UnmountDMG

--- a/ui/References/macOS/HelperProjects/uninstaller/etc/install.sh
+++ b/ui/References/macOS/HelperProjects/uninstaller/etc/install.sh
@@ -11,6 +11,10 @@ _app_path="/Applications/IVPN.app"
 _app_plist="${_app_path}/Contents/Info.plist"
 _app_backup="${_app_path}.old"
 
+# Ensure copied files are created with user-readable defaults even if parent process
+# runs with a restrictive umask (e.g. 077).
+umask 022
+
 function echoerr
 {
   echo "[!] ERROR: $@" 1>&2;
@@ -102,6 +106,15 @@ function CheckSignature
     return 0
 }
 
+function FixInstalledAppPermissions
+{
+    # Make app bundle traversable/readable for normal users while preserving
+    # executable bits for binaries and scripts.
+    chown -R root:wheel "${_app_path}" || return 1
+    chmod -R a+rX,go-w "${_app_path}" || return 1
+    return 0
+}
+
 if [ -z "${_source_dmg}" ]; then
   echoerr "Source dmg file not defined."
   exit 64
@@ -179,6 +192,9 @@ fi
 
 echo "[+] Copying ..."
 cp -R "${_app_path_src}" "${_app_path}" || { echoerr "Failed to install the update"; RestoreBackup; UnmountDMG; exit 72; }
+
+echo "[+] Fixing permissions ..."
+FixInstalledAppPermissions || { echoerr "Failed to fix application permissions"; RestoreBackup; UnmountDMG; exit 73; }
 
 RemoveBackup
 UnmountDMG

--- a/ui/src/app-updater/index.js
+++ b/ui/src/app-updater/index.js
@@ -66,6 +66,12 @@ export function IsNewerVersion(updatesInfo, currDaemonVer, currUiVer) {
   return updater.IsNewerVersion(updatesInfo, currDaemonVer, currUiVer);
 }
 
+export function IsOsCompatible(updatesInfo) {
+  const updater = getUpdater();
+  if (!updater?.IsOsCompatible) return true;
+  return updater.IsOsCompatible(updatesInfo);
+}
+
 export function StartUpdateChecker(onHasUpdateCallback) {
   if (!onHasUpdateCallback) {
     console.warn("Unable to start update checker: callback not defined");
@@ -94,6 +100,9 @@ export function StartUpdateChecker(onHasUpdateCallback) {
         if (updater.IsNewerVersion(updatesInfo, currDaemonVer, currUiVer)) {
           if (updater.IsNeedSkipThisVersion(updatesInfo)) {
             return;
+          }
+          if (updater.IsOsCompatible && !updater.IsOsCompatible(updatesInfo)) {
+            return; // OS does not meet minimum required version — skip silently
           }
 
           onHasUpdateCallback(updatesInfo, currDaemonVer, currUiVer);
@@ -134,6 +143,10 @@ export async function CheckUpdates(isAutomaticCheck) {
       isAutomaticCheck,
       settingsUpdates ? settingsUpdates.isBetaProgram : null
     );
+    // _isOsCompatible is a runtime-computed flag, not part of server JSON
+    if (updatesInfo && updater?.IsOsCompatible) {
+      updatesInfo._isOsCompatible = updater.IsOsCompatible(updatesInfo);
+    }
     store.commit("latestVersionInfo", updatesInfo);
 
     setState({

--- a/ui/src/app-updater/updater_generic.js
+++ b/ui/src/app-updater/updater_generic.js
@@ -121,6 +121,18 @@ export function IsNeedSkipThisVersion(updatesInfo) {
   );
 }
 
+// minOsVersion format: "X", "X.Y", or "X.Y.Z"  (e.g. "12" = macOS 12+, "10.0.19041" = Win10 build 19041+)
+export function IsOsCompatible(updatesInfo) {
+  const minVer = updatesInfo?.generic?.minOsVersion;
+  if (!minVer) return true;
+  try {
+    return !IsNewVersion(process.getSystemVersion(), minVer);
+  } catch (e) {
+    console.warn("[updater] OS version check failed:", e);
+    return true; // fail-open: never silently block an update
+  }
+}
+
 function setState(updateState) {
   // logging
   try {

--- a/ui/src/views/dialogs/Dlg-Update.vue
+++ b/ui/src/views/dialogs/Dlg-Update.vue
@@ -38,6 +38,10 @@
                       (daemon v{{ versionDaemon }}; UI v{{ versionUI }})
                     </div>
                   </div>
+                  <!-- OS-incompatible update exists -->
+                  <div v-if="isOsIncompatible" class="small_text" style="margin-top: 10px; color: orange">
+                    Version {{ versionLatestGeneric }} is available but requires OS version {{ latestVersionInfo.generic.minOsVersion }} or later.
+                  </div>
                 </div>
                 <div class="buttons">
                   <button class="slave btn" v-on:click="onCancel">Close</button>
@@ -247,7 +251,14 @@ export default {
     isCheckingUpdate: function () {
       return this.updateState == AppUpdateStage.CheckingForUpdates;
     },
+    isOsCompatible: function () {
+      return this.$store.state.latestVersionInfo?._isOsCompatible !== false;
+    },
+    isOsIncompatible: function () {
+      return !this.isOsCompatible && !!this.versionLatestGeneric;
+    },
     isHasUpgrade: function () {
+      if (!this.isOsCompatible) return false;
       if (this.versionLatestGeneric) {
         return (
           IsNewVersion(this.versionDaemon, this.versionLatestGeneric) ||

--- a/ui/src/views/dialogs/Dlg-Update.vue
+++ b/ui/src/views/dialogs/Dlg-Update.vue
@@ -104,6 +104,8 @@
                   class="releaseNotes scrollableColumnContainer"
                   style="max-height: 350px"
                 >
+                  <!-- generic.notes: optional free-text shown above release notes -->
+                  <div v-if="latestVersionInfo.generic && latestVersionInfo.generic.notes" class="relNotesPreText" style="white-space: pre-wrap; margin-bottom: 10px;">{{ latestVersionInfo.generic.notes }}</div>
                   <!--release notes GENERIC-->
                   <div v-if="versionLatestGeneric">
                     <div class="relNotesPreText">Release notes:</div>


### PR DESCRIPTION
## app-updater: minOsVersion gating, optional notes, macOS permission fixes (#565)

### Summary

### Changes

#### - `minOsVersion` OS compatibility gating

Adds support for an optional `minOsVersion` field in the update JSON. When present:

- The automatic update checker silently skips the notification if the running OS is older than the required version.
- The manual "Check for updates" dialog shows an informational warning and hides the download button instead of offering an uninstallable update.
- Omitting the field keeps existing behavior (fully backward-compatible).

Supported format: `"X"`, `"X.Y"`, or `"X.Y.Z"` (e.g. `"12"` for macOS 12+, `"10.0.19041"` for Windows 10 build 19041+).  
The check **fails open** - if the OS version cannot be parsed, the update is shown.

#### - Optional `generic.notes` in the update dialog

The update dialog now renders `generic.notes` (if present in the update JSON) as pre-formatted text above the release notes section.

#### - macOS updater: umask and permission handling (#565)

- Sets `umask 022` at the top of `install.sh` so files copied during an update are world-readable even when the parent process runs with a restrictive umask (e.g. `077`).

---

### Testing

- [x] Auto-update notification is suppressed when `minOsVersion` exceeds current OS
- [x] Auto-update notification appears normally when `minOsVersion` is met or absent
- [x] Update dialog shows orange warning and hides download button for incompatible OS
- [x] `generic.notes` renders above release notes; absent field renders nothing
- [x] macOS update succeeds when parent process has `umask 077`
