### PR TITLE
fix(cli): parsing of default IPv6 route (#447)

### DIFF
--- a/daemon/References/Linux/etc/splittun.sh
+++ b/daemon/References/Linux/etc/splittun.sh
@@ -159,7 +159,7 @@ function detectDefRouteVars()
 
     if [ -z ${_def_gatewayIPv6} ] || [ -z ${_def_interface_nameIPv6} ]; then
         if [ -f /proc/net/if_inet6 ]; then
-            read -r _def_gatewayIPv6 _def_interface_nameIPv6 <<< $(${_bin_ip} -6 route | awk '/default/  {print $3, $5}')
+            read -r _def_gatewayIPv6 _def_interface_nameIPv6 <<< $(${_bin_ip} -6 route | awk '/default/  {print $5, $7}')
             echo "[+] Detected default IPv6 route: gateway='${_def_gatewayIPv6}' interface='${_def_interface_nameIPv6}'"
         fi
     fi


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] I have added necessary documentation (if appropriate)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```
$ ivpn exclude COMMAND
Error: Failed to enable Split Tunnel: (exit status 2) ip6tables v1.8.13 (nf_tables): interface name `xxxx::xxxx:xxxx:xxxx:xxxx' must be shorter than 16 characters
Try `ip6tables -h' or 'ip6tables --help' for more information.
```

Issue number: #447

## What is the new behavior?

```
$ ivpn exclude COMMAND
Running command in Split Tunneling environment (pid:XXXXXX): COMMAND
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
